### PR TITLE
[Free Convection] Add option for convolutional layer in NN and soft causality enforcement during training.

### DIFF
--- a/free_convection/train_free_convection_nde.jl
+++ b/free_convection/train_free_convection_nde.jl
@@ -159,13 +159,13 @@ coarse_training_datasets = Dict(id => coarse_datasets[id] for id in ids_train)
 coarse_testing_datasets = Dict(id => coarse_datasets[id] for id in ids_test)
 
 ## Create animations for T(z,t) and wT(z,t)
-#=
+
 @info "Animating training data..."
 for id in keys(training_datasets)
     filepath = joinpath(output_dir, "free_convection_data_$id")
     animate_data(training_datasets[id], coarse_training_datasets[id]; filepath, frameskip=5)
 end
-=#
+
 ## Pull out input (T) and output (wT) training data
 
 @info "Wrangling training data..."


### PR DESCRIPTION
Added two new arguments, 'conv' and 'spatial_causality', to train_free_convection_nde.jl. 

The former allows for the specification of a desired convolutional filter size at run-time. 

The latter toggles whether a penalty for spatial causality (i.e. that predictions for a grid point should only depend on grid points above) is added to the loss function throughout both phases of training. Concretely, if args['spatial_causality'] == 'soft', we add abs(weight)^2 for each weight value off of the lower triangle of the first dense layer in the NN at each training timestep to the loss. 